### PR TITLE
lima: add resource_from_handle support

### DIFF
--- a/src/gallium/drivers/lima/lima.h
+++ b/src/gallium/drivers/lima/lima.h
@@ -34,6 +34,7 @@ enum lima_gpu_type {
 enum lima_bo_handle_type {
    lima_bo_handle_type_gem_flink_name = 0,
    lima_bo_handle_type_kms = 1,
+   lima_bo_handle_type_dma_buf_fd = 2,
 };
 
 struct lima_device_info {

--- a/src/gallium/drivers/lima/lima_bo.c
+++ b/src/gallium/drivers/lima/lima_bo.c
@@ -23,6 +23,9 @@
 
 #include <stdlib.h>
 #include <errno.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
 
 #include "xf86drm.h"
 #include "lima_priv.h"
@@ -32,6 +35,14 @@
 #include "util/macros.h"
 #include "util/u_atomic.h"
 #include "os/os_mman.h"
+
+static void lima_close_kms_handle(lima_device_handle dev, uint32_t handle)
+{
+   struct drm_gem_close args = {};
+
+   args.handle = handle;
+   drmIoctl(dev->fd, DRM_IOCTL_GEM_CLOSE, &args);
+}
 
 int lima_bo_create(lima_device_handle dev, struct lima_bo_create_request *request,
                    lima_bo_handle *bo_handle)
@@ -64,10 +75,6 @@ int lima_bo_create(lima_device_handle dev, struct lima_bo_create_request *reques
 
 int lima_bo_free(lima_bo_handle bo)
 {
-   int err;
-   struct drm_gem_close req = {
-      .handle = bo->handle,
-   };
 
    if (!p_atomic_dec_zero(&bo->refcnt))
       return 0;
@@ -78,9 +85,9 @@ int lima_bo_free(lima_bo_handle bo)
       util_hash_table_remove(bo->dev->bo_flink_names, (void *)bo->flink_name);
    pthread_mutex_unlock(&bo->dev->bo_table_mutex);
 
-   err = drmIoctl(bo->dev->fd, DRM_IOCTL_GEM_CLOSE, &req);
+   lima_close_kms_handle(bo->dev, bo->handle);
    free(bo);
-   return err;
+   return 0;
 }
 
 void *lima_bo_map(lima_bo_handle bo)
@@ -173,6 +180,9 @@ int lima_bo_export(lima_bo_handle bo, enum lima_bo_handle_type type,
 
       *handle = bo->handle;
       return 0;
+   case lima_bo_handle_type_dma_buf_fd:
+      /* unsupported yet */
+      return -EINVAL;
    }
 
    return -EINVAL;
@@ -184,8 +194,35 @@ int lima_bo_import(lima_device_handle dev, enum lima_bo_handle_type type,
    int err;
    lima_bo_handle bo = NULL;
    struct drm_gem_open req = {0};
+   uint64_t dma_buf_size = 0;
 
    pthread_mutex_lock(&dev->bo_table_mutex);
+
+   /* Convert a DMA buf handle to a KMS handle now. */
+   if (type == lima_bo_handle_type_dma_buf_fd) {
+      uint32_t prime_handle;
+      off_t size;
+
+      /* Get a KMS handle. */
+      err = drmPrimeFDToHandle(dev->fd, handle, &prime_handle);
+      if (err) {
+         pthread_mutex_unlock(&dev->bo_table_mutex);
+         return err;
+      }
+
+      /* Query the buffer size. */
+      size = lseek(handle, 0, SEEK_END);
+      if (size == (off_t)-1) {
+         pthread_mutex_unlock(&dev->bo_table_mutex);
+         lima_close_kms_handle(dev, prime_handle);
+         return -errno;
+      }
+      lseek(handle, 0, SEEK_SET);
+
+      dma_buf_size = size;
+      handle = prime_handle;
+   }
+
    switch (type) {
    case lima_bo_handle_type_gem_flink_name:
       bo = util_hash_table_get(dev->bo_flink_names, (void *)handle);
@@ -193,20 +230,30 @@ int lima_bo_import(lima_device_handle dev, enum lima_bo_handle_type type,
    case lima_bo_handle_type_kms:
       bo = util_hash_table_get(dev->bo_handles, (void *)handle);
       break;
+   case lima_bo_handle_type_dma_buf_fd:
+      bo = util_hash_table_get(dev->bo_handles, (void *)handle);
+      break;
+   default:
+      pthread_mutex_unlock(&dev->bo_table_mutex);
+      return -EINVAL;
    }
-   pthread_mutex_unlock(&dev->bo_table_mutex);
 
    if (bo) {
       p_atomic_inc(&bo->refcnt);
       result->bo = bo;
       result->size = bo->size;
+      pthread_mutex_unlock(&dev->bo_table_mutex);
       return 0;
    }
 
    bo = calloc(1, sizeof(*bo));
-   if (!bo)
+   if (!bo) {
+      pthread_mutex_unlock(&dev->bo_table_mutex);
+      if (type == lima_bo_handle_type_dma_buf_fd) {
+         lima_close_kms_handle(dev, handle);
+      }
       return -ENOMEM;
-
+   }
    bo->dev = dev;
    p_atomic_set(&bo->refcnt, 1);
 
@@ -216,21 +263,28 @@ int lima_bo_import(lima_device_handle dev, enum lima_bo_handle_type type,
       err = drmIoctl(dev->fd, DRM_IOCTL_GEM_OPEN, &req);
       if (err) {
          free(bo);
+         pthread_mutex_unlock(&dev->bo_table_mutex);
          return err;
       }
       bo->handle = req.handle;
       bo->flink_name = handle;
       bo->size = req.size;
 
-      pthread_mutex_lock(&dev->bo_table_mutex);
       util_hash_table_set(bo->dev->bo_flink_names, (void *)bo->flink_name, bo);
       pthread_mutex_unlock(&dev->bo_table_mutex);
       break;
    case lima_bo_handle_type_kms:
       /* not possible */
       free(bo);
+      pthread_mutex_unlock(&dev->bo_table_mutex);
       return -EINVAL;
+   case lima_bo_handle_type_dma_buf_fd:
+      bo->handle = handle;
+      bo->size = dma_buf_size;
+      break;
    }
+   util_hash_table_set(dev->bo_handles, (void*)bo->handle, bo);
+   pthread_mutex_unlock(&dev->bo_table_mutex);
 
    result->bo = bo;
    result->size = bo->size;

--- a/src/gallium/drivers/lima/lima_resource.c
+++ b/src/gallium/drivers/lima/lima_resource.c
@@ -162,6 +162,58 @@ lima_resource_destroy(struct pipe_screen *pscreen, struct pipe_resource *pres)
    FREE(res);
 }
 
+static struct pipe_resource *
+lima_resource_from_handle(struct pipe_screen *pscreen,
+        const struct pipe_resource *templat,
+        struct winsys_handle *handle, unsigned usage)
+{
+   struct lima_resource *res;
+   struct lima_screen *screen = lima_screen(pscreen);
+   struct lima_bo_import_result result = {0};
+   enum lima_bo_handle_type type;
+   int r;
+
+   switch (handle->type) {
+   case DRM_API_HANDLE_TYPE_FD:
+      type = lima_bo_handle_type_dma_buf_fd;
+      break;
+   default:
+      return NULL;
+   }
+
+   res = CALLOC_STRUCT(lima_resource);
+   if (!res)
+      return NULL;
+
+   res->buffer = CALLOC_STRUCT(lima_buffer);
+   if (!res->buffer)
+      return NULL;
+
+   struct pipe_resource *pres = &res->base;
+
+   *pres = *templat;
+
+   pres->screen = pscreen;
+
+   r = lima_bo_import(screen->dev, type, handle->handle, &result);
+   if (r)
+      goto fail;
+
+   res->buffer->bo = result.bo;
+   res->buffer->size = result.size;
+
+   res->stride = handle->stride;
+   res->buffer->screen = screen;
+
+   pipe_reference_init(&pres->reference, 1);
+
+   return pres;
+
+fail:
+   lima_resource_destroy(pscreen, pres);
+   return NULL;
+}
+
 static boolean
 lima_resource_get_handle(struct pipe_screen *pscreen,
                          struct pipe_context *pctx,
@@ -194,6 +246,7 @@ void
 lima_resource_screen_init(struct lima_screen *screen)
 {
    screen->base.resource_create = lima_resource_create;
+   screen->base.resource_from_handle = lima_resource_from_handle;
    screen->base.resource_destroy = lima_resource_destroy;
    screen->base.resource_get_handle = lima_resource_get_handle;
 }


### PR DESCRIPTION
Defines lima_resource_from_handle and adds resource_from_handle support.
This is to be used to share a dmabuf with a kms display driver so that
we can use lima to render to a buffer being output to a display.

This targets the Allwinner A20 support with the Display Engine
(sun4i_drm) driver.

Signed-off-by: Erico Nunes <nunes.erico@gmail.com>