### PR TITLE
lima: support exporting dma_buf

### DIFF
--- a/src/gallium/drivers/lima/lima_bo.c
+++ b/src/gallium/drivers/lima/lima_bo.c
@@ -180,8 +180,13 @@ int lima_bo_export(lima_bo_handle bo, enum lima_bo_handle_type type,
       *handle = bo->handle;
       return 0;
    case lima_bo_handle_type_dma_buf_fd:
-      /* unsupported yet */
-      return -EINVAL;
+      err = drmPrimeHandleToFD(bo->dev->fd, bo->handle, DRM_CLOEXEC, (int*)handle);
+      if (err)
+         return err;
+      pthread_mutex_lock(&bo->dev->bo_table_mutex);
+      util_hash_table_set(bo->dev->bo_handles, (void *)bo->handle, bo);
+      pthread_mutex_unlock(&bo->dev->bo_table_mutex);
+      return 0;
    }
 
    return -EINVAL;

--- a/src/gallium/drivers/lima/lima_resource.c
+++ b/src/gallium/drivers/lima/lima_resource.c
@@ -236,6 +236,12 @@ lima_resource_get_handle(struct pipe_screen *pscreen,
       err = lima_bo_export(bo, lima_bo_handle_type_kms, &handle->handle);
       if (err)
          return FALSE;
+      break;
+   case DRM_API_HANDLE_TYPE_FD:
+      err = lima_bo_export(bo, lima_bo_handle_type_dma_buf_fd, &handle->handle);
+      if (err)
+         return FALSE;
+      break;
    default:
       return FALSE;
    }


### PR DESCRIPTION
This enables lima to export a shared buffer from a dma_buf handle using
the DRM prime infrastructure.
With this, it is possible to export a gbm_bo allocated with lima to the
display driver for rendering to a display.

This was tested on the Allwinner A20 with the sun4i-drm driver, along
with lima.

Signed-off-by: Erico Nunes <nunes.erico@gmail.com>