### PR TITLE
Basic Mali450 support

### DIFF
--- a/include/drm-uapi/lima_drm.h
+++ b/include/drm-uapi/lima_drm.h
@@ -29,6 +29,7 @@ extern "C" {
 #endif
 
 #define LIMA_INFO_GPU_MALI400 0x00
+#define LIMA_INFO_GPU_MALI450 0x01
 
 struct drm_lima_info {
 	__u32 gpu_id;  /* out */

--- a/src/gallium/drivers/lima/lima.h
+++ b/src/gallium/drivers/lima/lima.h
@@ -29,6 +29,7 @@
 
 enum lima_gpu_type {
    GPU_MALI400,
+   GPU_MALI450,
 };
 
 enum lima_bo_handle_type {

--- a/src/gallium/drivers/lima/lima_device.c
+++ b/src/gallium/drivers/lima/lima_device.c
@@ -102,6 +102,9 @@ int lima_device_query_info(lima_device_handle dev, struct lima_device_info *info
    case LIMA_INFO_GPU_MALI400:
       info->gpu_type = GPU_MALI400;
       break;
+   case LIMA_INFO_GPU_MALI450:
+      info->gpu_type = GPU_MALI450;
+      break;
    default:
       return -ENODEV;
    }

--- a/src/gallium/drivers/lima/lima_screen.c
+++ b/src/gallium/drivers/lima/lima_screen.c
@@ -49,7 +49,14 @@ lima_screen_destroy(struct pipe_screen *pscreen)
 static const char *
 lima_screen_get_name(struct pipe_screen *pscreen)
 {
-   return "Mali400";
+   struct lima_screen *screen = lima_screen(pscreen);
+
+   switch (screen->info.gpu_type) {
+   case GPU_MALI400:
+     return "Mali400";
+   case GPU_MALI450:
+     return "Mali450";
+   }
 }
 
 static const char *


### PR DESCRIPTION
Can run the kmscube -d sample on both the older Mali400 (rk3188 for me), as well as Mali450MP2 (rk3328 in this case).