### PR TITLE
lima: Implement scissor support

### DIFF
--- a/src/gallium/drivers/lima/lima_draw.c
+++ b/src/gallium/drivers/lima/lima_draw.c
@@ -353,7 +353,7 @@ lima_pack_plbu_cmd(struct lima_context *ctx, const struct pipe_draw_info *info)
       ctx->buffer_state[lima_ctx_buff_pp_plb_rsw].size;
    plbu_cmd[i++] = 0x80000000 | (gl_position_va >> 4); /* RSW_VERTEX_ARRAY */
 
-   if (ctx->dirty & LIMA_CONTEXT_DIRTY_SCISSOR) {
+   if (ctx->rasterizer->base.scissor) {
       struct pipe_scissor_state *scissor = &ctx->scissor;
       plbu_cmd[i++] = (scissor->minx << 30) | (scissor->maxy - 1) << 15 | scissor->miny;
       plbu_cmd[i++] = 0x70000000 | (scissor->maxx - 1) << 13 | (scissor->minx >> 2); /* PLBU_CMD_SCISSORS */
@@ -827,7 +827,7 @@ lima_update_pp_fs_program(struct lima_context *ctx)
 static bool
 lima_is_scissor_zero(struct lima_context *ctx)
 {
-   if (!(ctx->dirty & LIMA_CONTEXT_DIRTY_SCISSOR))
+   if (!ctx->rasterizer->base.scissor)
       return false;
 
    struct pipe_scissor_state *scissor = &ctx->scissor;

--- a/src/gallium/drivers/lima/lima_draw.c
+++ b/src/gallium/drivers/lima/lima_draw.c
@@ -353,6 +353,12 @@ lima_pack_plbu_cmd(struct lima_context *ctx, const struct pipe_draw_info *info)
       ctx->buffer_state[lima_ctx_buff_pp_plb_rsw].size;
    plbu_cmd[i++] = 0x80000000 | (gl_position_va >> 4); /* RSW_VERTEX_ARRAY */
 
+   if (ctx->dirty & LIMA_CONTEXT_DIRTY_SCISSOR) {
+      struct pipe_scissor_state *scissor = &ctx->scissor;
+      plbu_cmd[i++] = (scissor->minx << 30) | (scissor->maxy - 1) << 15 | scissor->miny;
+      plbu_cmd[i++] = 0x70000000 | (scissor->maxx - 1) << 13 | (scissor->minx >> 2); /* PLBU_CMD_SCISSORS */
+   }
+
    plbu_cmd[i++] = 0x00000000;
    plbu_cmd[i++] = 0x1000010A; /* ?? */
 

--- a/src/gallium/drivers/lima/lima_program.c
+++ b/src/gallium/drivers/lima/lima_program.c
@@ -162,8 +162,7 @@ lima_create_fs_state(struct pipe_context *pctx,
    else {
       assert(cso->type == PIPE_SHADER_IR_TGSI);
 
-      /* not supported */
-      assert(0);
+      nir = tgsi_to_nir(cso->tokens, &fs_nir_options);
    }
 
    lima_program_optimize_fs_nir(nir);
@@ -219,8 +218,7 @@ lima_create_vs_state(struct pipe_context *pctx,
    else {
       assert(cso->type == PIPE_SHADER_IR_TGSI);
 
-      /* not supported */
-      assert(0);
+      nir = tgsi_to_nir(cso->tokens, &vs_nir_options);
    }
 
    lima_program_optimize_vs_nir(nir);

--- a/src/gallium/drivers/lima/lima_program.c
+++ b/src/gallium/drivers/lima/lima_program.c
@@ -75,6 +75,8 @@ lima_program_optimize_vs_nir(struct nir_shader *s)
 {
    bool progress;
 
+   NIR_PASS_V(s, nir_opt_global_to_local);
+   NIR_PASS_V(s, nir_lower_regs_to_ssa);
    NIR_PASS_V(s, nir_lower_load_const_to_scalar);
    NIR_PASS_V(s, nir_lower_io_to_scalar,
               nir_var_shader_in|nir_var_shader_out|nir_var_uniform);
@@ -110,6 +112,9 @@ static void
 lima_program_optimize_fs_nir(struct nir_shader *s)
 {
    bool progress;
+
+   NIR_PASS_V(s, nir_opt_global_to_local);
+   NIR_PASS_V(s, nir_lower_regs_to_ssa);
 
    do {
       progress = false;


### PR DESCRIPTION
For scissor 0,0,0,0 we're skipping any drawings, for other cases it's calculated the same way as limadriver.
Had to add support for tgsi shaders - it's done in the same way as vc4/freedreno (we can convert them from tgsi to nir) and use nir_opt_global_to_local and nir_lower_regs_to_ssa nir pass.
