### PR TITLE
Tgsi nir fixes

### DIFF
--- a/src/gallium/drivers/lima/lima_program.c
+++ b/src/gallium/drivers/lima/lima_program.c
@@ -162,8 +162,7 @@ lima_create_fs_state(struct pipe_context *pctx,
    else {
       assert(cso->type == PIPE_SHADER_IR_TGSI);
 
-      /* not supported */
-      assert(0);
+      nir = tgsi_to_nir(cso->tokens, &fs_nir_options);
    }
 
    lima_program_optimize_fs_nir(nir);
@@ -219,8 +218,7 @@ lima_create_vs_state(struct pipe_context *pctx,
    else {
       assert(cso->type == PIPE_SHADER_IR_TGSI);
 
-      /* not supported */
-      assert(0);
+      nir = tgsi_to_nir(cso->tokens, &vs_nir_options);
    }
 
    lima_program_optimize_vs_nir(nir);

--- a/src/gallium/drivers/lima/lima_program.c
+++ b/src/gallium/drivers/lima/lima_program.c
@@ -38,6 +38,7 @@
 #include "ir/lima_ir.h"
 
 static const nir_shader_compiler_options vs_nir_options = {
+   .lower_ffma = true,
    .lower_fpow = true,
    .lower_ffract = true,
    .lower_fdiv = true,

--- a/src/gallium/drivers/lima/lima_program.c
+++ b/src/gallium/drivers/lima/lima_program.c
@@ -75,6 +75,8 @@ lima_program_optimize_vs_nir(struct nir_shader *s)
 {
    bool progress;
 
+   NIR_PASS_V(s, nir_opt_global_to_local);
+   NIR_PASS_V(s, nir_lower_regs_to_ssa);
    NIR_PASS_V(s, nir_lower_load_const_to_scalar);
    NIR_PASS_V(s, nir_lower_io_to_scalar,
               nir_var_shader_in|nir_var_shader_out|nir_var_uniform);
@@ -110,6 +112,9 @@ static void
 lima_program_optimize_fs_nir(struct nir_shader *s)
 {
    bool progress;
+
+   NIR_PASS_V(s, nir_opt_global_to_local);
+   NIR_PASS_V(s, nir_lower_regs_to_ssa);
 
    do {
       progress = false;


### PR DESCRIPTION
Those were found during my work on getting scissor working.

First patch enables shader conversion from tgsi to nir (based on vc4/freedreno).
It can be reproduced by starting piglit test
```
$ PIGLIT_PLATFORM=gbm ./bin/gl-1.0-scissor-copypixels -auto -fbo
```


Last patch enables lowering ffma. It fixes following error
```
$ PIGLIT_PLATFORM=gbm ./bin/gl-1.0-scissor-offscreen -auto -fbo
gpir: unsupport nir_op 66
```