### PR TITLE
Scissor support

### DIFF
--- a/src/gallium/drivers/lima/lima_draw.c
+++ b/src/gallium/drivers/lima/lima_draw.c
@@ -286,6 +286,18 @@ lima_pack_vs_cmd(struct lima_context *ctx, const struct pipe_draw_info *info)
    ctx->buffer_state[lima_ctx_buff_gp_vs_cmd].size = i * 4;
 }
 
+static bool
+lima_is_scissor_zero(struct lima_context *ctx)
+{
+   if (!ctx->rasterizer->base.scissor)
+      return false;
+
+   struct pipe_scissor_state *scissor = &ctx->scissor;
+   return
+      scissor->minx == scissor->maxx
+      && scissor->miny == scissor->maxy;
+}
+
 static void
 lima_pack_plbu_cmd(struct lima_context *ctx, const struct pipe_draw_info *info)
 {
@@ -327,6 +339,10 @@ lima_pack_plbu_cmd(struct lima_context *ctx, const struct pipe_draw_info *info)
       plbu_cmd[i++] = fui(ctx->viewport.height);
       plbu_cmd[i++] = 0x10000106; /* VIEWPORT_H */
    }
+
+   /* If it's zero scissor, we skip adding all other commands */
+   if (lima_is_scissor_zero(ctx))
+      goto done;
 
    if (!info->index_size) {
       plbu_cmd[i++] = 0x00010002; /* ARRAYS_SEMAPHORE_BEGIN */
@@ -398,6 +414,7 @@ lima_pack_plbu_cmd(struct lima_context *ctx, const struct pipe_draw_info *info)
          ((info->mode & 0x1F) << 16) | (info->count >> 8); /* DRAW | DRAW_ELEMENTS */
    }
 
+done:
    if (lima_dump_command_stream) {
       printf("lima add plbu cmd at va %x\n",
              ctx->gp_buffer->va + gp_plbu_cmd_offset +
@@ -866,7 +883,11 @@ lima_draw_vbo(struct pipe_context *pctx, const struct pipe_draw_info *info)
       lima_update_gp_vs_program(ctx);
 
    lima_update_varying(ctx, info);
-   lima_pack_vs_cmd(ctx, info);
+
+   /* If it's zero scissor, don't build vs cmd list */
+   if (!lima_is_scissor_zero(ctx))
+      lima_pack_vs_cmd(ctx, info);
+
    lima_pack_plbu_cmd(ctx, info);
 
    lima_bo_wait(ctx->pp_buffer->bo, LIMA_BO_WAIT_FLAG_WRITE, 1000000000, true);

--- a/src/gallium/drivers/lima/lima_draw.c
+++ b/src/gallium/drivers/lima/lima_draw.c
@@ -353,6 +353,16 @@ lima_pack_plbu_cmd(struct lima_context *ctx, const struct pipe_draw_info *info)
       ctx->buffer_state[lima_ctx_buff_pp_plb_rsw].size;
    plbu_cmd[i++] = 0x80000000 | (gl_position_va >> 4); /* RSW_VERTEX_ARRAY */
 
+   /* TODO
+    * - we should set it only for the first draw that enabled the scissor and for latter draw only if scissor is dirty
+    * - check why scissor is not affecting bounds of region cleared by glClear
+    */
+   if (ctx->rasterizer->base.scissor) {
+      struct pipe_scissor_state *scissor = &ctx->scissor;
+      plbu_cmd[i++] = (scissor->minx << 30) | (scissor->maxy - 1) << 15 | scissor->miny;
+      plbu_cmd[i++] = 0x70000000 | (scissor->maxx - 1) << 13 | (scissor->minx >> 2); /* PLBU_CMD_SCISSORS */
+   }
+
    plbu_cmd[i++] = 0x00000000;
    plbu_cmd[i++] = 0x1000010A; /* ?? */
 


### PR DESCRIPTION
This commit adds scissor support.

- for non zero scissor we just add plbu cmd with scissor (taken from lima-ng).
- for zero scissor we skip building plbu cmd after header and don't buld vs cmds (in previous patch i was trying to skip drawing in this case but then we would see state/image like in previous frame).
This behaviour has been found by comparing binary driver memory dump with and without zero scissor.

It was tested with following sample https://github.com/PabloPL/gfx/tree/scissor-test/gbm-surface-scissor
It's just a copy of gbm-surface-move where it should display following data:
- frame0 - normal image
- frame1 - non zero scissor
- frame2 - non zero scissor
- frame3 - zero scissor
- frame4 - normal image
Where non zero scissor is (0, 0, half of screen, half of screen), so result is top left quarter of screen.

Also during testing it's good to change this order, so first is zero scissor and later non zero, with previous implementation (where we're just skipping all in draw_vbo) this was not working (displaying the same image as in previous frame).
