### PR TITLE
Lima 17.3 textures support

### DIFF
--- a/src/gallium/drivers/lima/Makefile.sources
+++ b/src/gallium/drivers/lima/Makefile.sources
@@ -47,4 +47,6 @@ C_SOURCES := \
 	  lima_vamgr.h \
 	  lima_util.c \
 	  lima_util.h \
+	  lima_texture.c \
+	  lima_texture.h \
 	  $(ir_SOURCES)

--- a/src/gallium/drivers/lima/ir/pp/node.c
+++ b/src/gallium/drivers/lima/ir/pp/node.c
@@ -119,11 +119,25 @@ const ppir_op_info ppir_op_infos[] = {
          PPIR_INSTR_SLOT_VARYING, PPIR_INSTR_SLOT_END
       },
    },
+   [ppir_op_load_coords] = {
+      .name = "ld_coords",
+      .type = ppir_node_type_load,
+      .slots = (int []) {
+         PPIR_INSTR_SLOT_VARYING, PPIR_INSTR_SLOT_END
+      },
+   },
    [ppir_op_load_uniform] = {
       .name = "ld_uni",
       .type = ppir_node_type_load,
       .slots = (int []) {
          PPIR_INSTR_SLOT_UNIFORM, PPIR_INSTR_SLOT_END
+      },
+   },
+   [ppir_op_load_texture] = {
+      .name = "ld_tex",
+      .type = ppir_node_type_load_texture,
+      .slots = (int []) {
+         PPIR_INSTR_SLOT_TEXLD, PPIR_INSTR_SLOT_END
       },
    },
    [ppir_op_const] = {
@@ -144,6 +158,7 @@ void *ppir_node_create(ppir_block *block, ppir_op op, int index, unsigned mask)
       [ppir_node_type_const] = sizeof(ppir_const_node),
       [ppir_node_type_load] = sizeof(ppir_load_node),
       [ppir_node_type_store] = sizeof(ppir_store_node),
+      [ppir_node_type_load_texture] = sizeof(ppir_load_texture_node),
    };
 
    ppir_node_type type = ppir_op_infos[op].type;

--- a/src/gallium/drivers/lima/ir/pp/node_to_instr.c
+++ b/src/gallium/drivers/lima/ir/pp/node_to_instr.c
@@ -37,6 +37,53 @@ static bool create_new_instr(ppir_block *block, ppir_node *node)
    return true;
 }
 
+static bool insert_to_load_tex(ppir_block *block, ppir_node *load_coords, ppir_node *ldtex)
+{
+   ppir_dest *dest = ppir_node_get_dest(ldtex);
+   ppir_node *move = NULL;
+
+   ppir_load_node *load = ppir_node_to_load(load_coords);
+   load->dest.type = ppir_target_pipeline;
+   load->dest.pipeline = ppir_pipeline_reg_discard;
+
+   ppir_load_texture_node *load_texture = ppir_node_to_load_texture(ldtex);
+   load_texture->src_coords.type = ppir_target_pipeline;
+   load_texture->src_coords.pipeline = ppir_pipeline_reg_discard;
+
+   /* Insert load_coords to ldtex instruction */
+   if (!ppir_instr_insert_node(ldtex->instr, load_coords))
+      return false;
+
+   /* Create move node */
+   move = ppir_node_create(block, ppir_op_mov, -1 , 0);
+   if (unlikely(!move))
+      return false;
+
+   ppir_debug("insert_load_tex: create move %d for %d\n",
+              move->index, ldtex->index);
+
+   ppir_alu_node *alu = ppir_node_to_alu(move);
+   alu->dest = *dest;
+
+   ppir_node_replace_succ(move, ldtex);
+
+   dest->type = ppir_target_pipeline;
+   dest->pipeline = ppir_pipeline_reg_sampler;
+
+   alu->num_src = 1;
+   ppir_node_target_assign(&alu->src[0], dest);
+   for (int i = 0; i < 4; i++)
+      alu->src->swizzle[i] = i;
+
+   ppir_node_add_dep(move, ldtex);
+   list_addtail(&move->list, &ldtex->list);
+
+   if (!ppir_instr_insert_node(ldtex->instr, move))
+      return false;
+
+   return true;
+}
+
 static bool insert_to_each_succ_instr(ppir_block *block, ppir_node *node)
 {
    ppir_dest *dest = ppir_node_get_dest(node);
@@ -181,10 +228,19 @@ static bool ppir_do_node_to_instr(ppir_block *block, ppir_node *node)
          if (!create_new_instr(block, node))
             return false;
       }
+      else if (node->op == ppir_op_load_coords) {
+         ppir_node *ldtex = ppir_node_first_succ(node);
+         if (!insert_to_load_tex(block, node, ldtex))
+            return false;
+      }
       else {
          /* not supported yet */
          return false;
       }
+      break;
+   case ppir_node_type_load_texture:
+      if (!create_new_instr(block, node))
+         return false;
       break;
    case ppir_node_type_const:
       if (!insert_to_each_succ_instr(block, node))

--- a/src/gallium/drivers/lima/lima_context.c
+++ b/src/gallium/drivers/lima/lima_context.c
@@ -26,6 +26,7 @@
 #include "util/u_upload_mgr.h"
 #include "util/u_math.h"
 #include "util/u_debug.h"
+#include "util/u_transfer.h"
 
 #include "lima_screen.h"
 #include "lima_context.h"
@@ -87,6 +88,7 @@ lima_context_create(struct pipe_screen *pscreen, void *priv, unsigned flags)
    ctx->uploader = u_upload_create_default(&ctx->base);
    ctx->base.stream_uploader = ctx->uploader;
    ctx->base.const_uploader = ctx->uploader;
+   ctx->base.texture_subdata = u_default_texture_subdata;
 
    slab_create_child(&ctx->transfer_pool, &screen->transfer_pool);
 

--- a/src/gallium/drivers/lima/lima_context.h
+++ b/src/gallium/drivers/lima/lima_context.h
@@ -122,12 +122,20 @@ enum lima_ctx_buff {
    lima_ctx_buff_pp_plb_rsw,
    lima_ctx_buff_pp_uniform_array,
    lima_ctx_buff_pp_uniform,
+   lima_ctx_buff_pp_tex_desc,
    lima_ctx_buff_num,
 };
 
 struct lima_ctx_buff_state {
    unsigned offset;
    unsigned size;
+};
+
+struct lima_texture_stateobj {
+   struct pipe_sampler_view *textures[PIPE_MAX_SAMPLERS];
+   unsigned num_textures;
+   struct pipe_sampler_state *samplers[PIPE_MAX_SAMPLERS];
+   unsigned num_samplers;
 };
 
 struct lima_context {
@@ -148,6 +156,7 @@ struct lima_context {
       LIMA_CONTEXT_DIRTY_BLEND        = (1 << 11),
       LIMA_CONTEXT_DIRTY_STENCIL_REF  = (1 << 12),
       LIMA_CONTEXT_DIRTY_CONST_BUFF   = (1 << 13),
+      LIMA_CONTEXT_DIRTY_TEXTURES     = (1 << 14),
    } dirty;
 
    struct u_upload_mgr *uploader;
@@ -168,6 +177,7 @@ struct lima_context {
    struct lima_blend_state *blend;
    struct pipe_stencil_ref stencil_ref;
    struct lima_context_constant_buffer const_buffer[PIPE_SHADER_TYPES];
+   struct lima_texture_stateobj tex_stateobj;
 
    struct lima_bo *share_buffer;
    #define sh_plb_offset             0x00000
@@ -190,15 +200,17 @@ struct lima_context {
    struct lima_bo *pp_buffer;
    #define pp_uniform_array_offset   0x00000
    #define pp_uniform_offset         0x00400
-   #define pp_frame_rsw_offset       0x01400
-   #define pp_clear_program_offset   0x01440
-   #define pp_plb_rsw_offset         0x01480
-   #define pp_plb_offset_start       0x02000
+   #define pp_tex_descs_offset       0x01400
+   #define pp_frame_rsw_offset       0x02400
+   #define pp_clear_program_offset   0x02440
+   #define pp_plb_rsw_offset         0x02480
+   #define pp_plb_offset_start       0x03000
    /* max_screen_w/h_size = 2048, max_pp = 4, plb_stream_size = ((max >> 4)^2 + max_pp) * 16 */
-   #define pp_stack_offset           0x42100
-   #define pp_buffer_size            0x44000
+   #define pp_stack_offset           0x43100
+   #define pp_buffer_size            0x45000
    #define pp_plb_offset(i, n)       \
       (pp_plb_offset_start + i * ((pp_stack_offset - pp_plb_offset_start) / n))
+
 
    struct lima_ctx_buff_state buffer_state[lima_ctx_buff_num];
 

--- a/src/gallium/drivers/lima/lima_context.h
+++ b/src/gallium/drivers/lima/lima_context.h
@@ -214,6 +214,26 @@ lima_context(struct pipe_context *pctx)
    return (struct lima_context *)pctx;
 }
 
+struct lima_sampler_state {
+   struct pipe_sampler_state base;
+};
+
+static inline struct lima_sampler_state *
+lima_sampler_state(struct pipe_sampler_state *psstate)
+{
+   return (struct lima_sampler_state *)psstate;
+}
+
+struct lima_sampler_view {
+   struct pipe_sampler_view base;
+};
+
+static inline struct lima_sampler_view *
+lima_sampler_view(struct pipe_sampler_view *psview)
+{
+   return (struct lima_sampler_view *)psview;
+}
+
 void lima_state_init(struct lima_context *ctx);
 void lima_state_fini(struct lima_context *ctx);
 void lima_draw_init(struct lima_context *ctx);

--- a/src/gallium/drivers/lima/lima_state.c
+++ b/src/gallium/drivers/lima/lima_state.c
@@ -364,6 +364,81 @@ lima_set_constant_buffer(struct pipe_context *pctx,
                 shader, index, cb->buffer, cb->buffer_offset, cb->buffer_size);
 }
 
+static void *
+lima_create_sampler_state(struct pipe_context *pctx,
+                         const struct pipe_sampler_state *cso)
+{
+   struct lima_sampler_state *so = CALLOC_STRUCT(lima_sampler_state);
+   if (!so)
+      return NULL;
+
+   debug_printf("%s: %p\n", __func__, so);
+
+   memcpy(so, cso, sizeof(*cso));
+
+   return so;
+}
+
+static void
+lima_sampler_state_delete(struct pipe_context *pctx, void *sstate)
+{
+   debug_printf("%s: %p\n", __func__, sstate);
+   free(sstate);
+}
+
+static void
+lima_sampler_states_bind(struct pipe_context *pctx,
+                        enum pipe_shader_type shader, unsigned start,
+                        unsigned nr, void **hwcso)
+{
+   debug_printf("%s: shader: %d, start: %d, nr: %d, hwcso: %p [0] %p\n", __func__, shader,
+                start, nr, hwcso, hwcso[0]);
+}
+
+static struct pipe_sampler_view *
+lima_create_sampler_view(struct pipe_context *pctx, struct pipe_resource *prsc,
+                        const struct pipe_sampler_view *cso)
+{
+   struct lima_sampler_view *so = CALLOC_STRUCT(lima_sampler_view);
+
+   if (!so)
+      return NULL;
+
+   debug_printf("%s: prsc: %p - %p\n", __func__, prsc, so);
+
+   so->base = *cso;
+
+   pipe_reference(NULL, &prsc->reference);
+   so->base.texture = prsc;
+   so->base.reference.count = 1;
+   so->base.context = pctx;
+
+   return &so->base;
+}
+
+static void
+lima_sampler_view_destroy(struct pipe_context *pctx,
+                         struct pipe_sampler_view *pview)
+{
+   struct lima_sampler_view *view = lima_sampler_view(pview);
+   struct lima_context *ctx = lima_context(pctx);
+
+   pipe_resource_reference(&pview->texture, NULL);
+
+   debug_printf("%s: %p\n", __func__, view);
+   free(view);
+}
+
+static void
+lima_set_sampler_views(struct pipe_context *pctx,
+                      enum pipe_shader_type shader,
+                      unsigned start, unsigned nr,
+                      struct pipe_sampler_view **views)
+{
+   debug_printf("%s: shader: %d, start: %d, nr: %d, views: %p [0] %p\n", __func__,
+                shader, start, nr, views, views[0]);
+}
+
 void
 lima_state_init(struct lima_context *ctx)
 {
@@ -392,6 +467,14 @@ lima_state_init(struct lima_context *ctx)
    ctx->base.create_vertex_elements_state = lima_create_vertex_elements_state;
    ctx->base.bind_vertex_elements_state = lima_bind_vertex_elements_state;
    ctx->base.delete_vertex_elements_state = lima_delete_vertex_elements_state;
+
+   ctx->base.create_sampler_state = lima_create_sampler_state;
+   ctx->base.delete_sampler_state = lima_sampler_state_delete;
+   ctx->base.bind_sampler_states = lima_sampler_states_bind;
+
+   ctx->base.create_sampler_view = lima_create_sampler_view;
+   ctx->base.sampler_view_destroy = lima_sampler_view_destroy;
+   ctx->base.set_sampler_views = lima_set_sampler_views;
 }
 
 void

--- a/src/gallium/drivers/lima/lima_texture.c
+++ b/src/gallium/drivers/lima/lima_texture.c
@@ -1,0 +1,210 @@
+/*
+ * Copyright (c) 2018 Lima Project
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sub license,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include "util/u_memory.h"
+#include "util/u_upload_mgr.h"
+#include "util/u_math.h"
+#include "util/u_debug.h"
+#include "util/u_transfer.h"
+
+#include "lima_bo.h"
+#include "lima_context.h"
+#include "lima_screen.h"
+#include "lima_texture.h"
+#include "lima_resource.h"
+#include "lima_submit.h"
+#include "lima_util.h"
+
+#include <lima_drm.h>
+
+#define LIMA_TEXEL_FORMAT_BGR_565      0x0e
+#define LIMA_TEXEL_FORMAT_RGB_888      0x15
+#define LIMA_TEXEL_FORMAT_RGBA_8888    0x16
+
+#define lima_tex_desc_size 64
+#define lima_tex_list_size 64
+
+static uint32_t pipe_format_to_lima(enum pipe_format pformat)
+{
+   unsigned swap_chans, flag1, format;
+
+   switch (pformat) {
+   case PIPE_FORMAT_R8G8B8A8_UNORM:
+   case PIPE_FORMAT_R8G8B8X8_UNORM:
+      swap_chans = 1;
+      flag1 = 0;
+      format = LIMA_TEXEL_FORMAT_RGBA_8888;
+      break;
+   case PIPE_FORMAT_B8G8R8A8_UNORM:
+   case PIPE_FORMAT_B8G8R8X8_UNORM:
+      swap_chans = 0;
+      flag1 = 0;
+      format = LIMA_TEXEL_FORMAT_RGBA_8888;
+      break;
+   case PIPE_FORMAT_R8G8B8_UNORM:
+      swap_chans = 1;
+      flag1 = 0;
+      format = LIMA_TEXEL_FORMAT_RGB_888;
+      break;
+   case PIPE_FORMAT_B5G6R5_UNORM:
+      swap_chans = 0;
+      flag1 = 0;
+      format = LIMA_TEXEL_FORMAT_BGR_565;
+      break;
+   default:
+      assert(0);
+      break;
+   }
+
+   return (swap_chans << 7) | (flag1 << 6) | format;
+}
+
+static void
+lima_update_tex_desc(struct lima_context *ctx, struct lima_sampler_state *sampler,
+                     struct lima_sampler_view *texture, void *pdesc)
+{
+   uint32_t *desc = pdesc;
+   unsigned width, height, layout;
+   struct pipe_resource *prsc = texture->base.texture;
+   struct lima_resource *lima_res = lima_resource(prsc);
+
+   /* TODO: - do we need to align width/height to 16?
+            - does hardware support stride different from width? */
+   width = prsc->width0;
+   height = prsc->height0;
+
+   /* "Swizzled" textures aren't supported yet */
+   layout = 0;
+
+   desc[0] = pipe_format_to_lima(prsc->format);
+
+   /* 2D texture */
+   desc[1] = 0x400;
+   desc[2] = (width << 22);
+   desc[3] = 0x10000 | (height << 3) | (width >> 10);
+   desc[6] = layout << 13;
+
+   lima_submit_add_bo(ctx->pp_submit, lima_res->bo, LIMA_SUBMIT_BO_READ);
+   lima_bo_update(lima_res->bo, false, true);
+
+   /* attach level 0 */
+   desc[6] &= ~0xc0000000;
+   desc[6] |= lima_res->bo->va << 24;
+   desc[7] &= ~0x00ffffff;
+   desc[7] |= lima_res->bo->va >> 8;
+
+   desc[1] &= ~0xff000000;
+   switch (sampler->base.mag_img_filter) {
+   case PIPE_TEX_FILTER_LINEAR:
+      desc[2] &= ~0x1000;
+      /* no mipmap, filter_mag = linear */
+      desc[1] |= 0x80000000;
+      break;
+   case PIPE_TEX_FILTER_NEAREST:
+   default:
+      desc[2] |= 0x1000;
+      break;
+   }
+
+   switch (sampler->base.min_img_filter) {
+      break;
+   case PIPE_TEX_FILTER_LINEAR:
+      desc[2] &= ~0x0800;
+      break;
+   case PIPE_TEX_FILTER_NEAREST:
+   default:
+      desc[2] |= 0x0800;
+      break;
+   }
+
+   /* Only clamp to edge and mirror repeat are supported */
+   desc[2] &= ~0xe000;
+   switch (sampler->base.wrap_s) {
+   case PIPE_TEX_WRAP_CLAMP:
+   case PIPE_TEX_WRAP_CLAMP_TO_EDGE:
+   case PIPE_TEX_WRAP_CLAMP_TO_BORDER:
+      desc[2] |= 0x2000;
+      break;
+   case PIPE_TEX_WRAP_REPEAT:
+   case PIPE_TEX_WRAP_MIRROR_REPEAT:
+      desc[2] |= 0x8000;
+      break;
+   }
+
+   /* Only clamp to edge and mirror repeat are supported */
+   desc[2] &= ~0x070000;
+   switch (sampler->base.wrap_s) {
+   case PIPE_TEX_WRAP_CLAMP:
+   case PIPE_TEX_WRAP_CLAMP_TO_EDGE:
+   case PIPE_TEX_WRAP_CLAMP_TO_BORDER:
+      desc[2] |= 0x010000;
+      break;
+   case PIPE_TEX_WRAP_REPEAT:
+   case PIPE_TEX_WRAP_MIRROR_REPEAT:
+      desc[2] |= 0x040000;
+      break;
+   }
+}
+
+void
+lima_update_textures(struct lima_context *ctx)
+{
+   struct lima_texture_stateobj *lima_tex = &ctx->tex_stateobj;
+
+   assert (lima_tex->num_samplers <= 16);
+
+   /* Nothing to do - we have no samplers */
+   if (!lima_tex->num_samplers)
+      return;
+
+   ctx->buffer_state[lima_ctx_buff_pp_tex_desc].offset +=
+      ctx->buffer_state[lima_ctx_buff_pp_tex_desc].size;
+   ctx->buffer_state[lima_ctx_buff_pp_tex_desc].size = 0;
+
+   uint32_t *descs = ctx->pp_buffer->map + pp_tex_descs_offset +
+                     ctx->buffer_state[lima_ctx_buff_pp_tex_desc].offset;
+   ctx->buffer_state[lima_ctx_buff_pp_tex_desc].size += lima_tex_list_size;
+
+   for (int i = 0; i < lima_tex->num_samplers; i++) {
+      off_t offset = ctx->buffer_state[lima_ctx_buff_pp_tex_desc].offset +
+                     pp_tex_descs_offset + lima_tex_desc_size * i +
+                     lima_tex_list_size;
+      struct lima_sampler_state *sampler = lima_sampler_state(lima_tex->samplers[i]);
+      struct lima_sampler_view *texture = lima_sampler_view(lima_tex->textures[i]);
+
+      descs[i] = ctx->pp_buffer->va + offset;
+      lima_update_tex_desc(ctx, sampler, texture, ctx->pp_buffer->map + offset);
+      ctx->buffer_state[lima_ctx_buff_pp_tex_desc].size += lima_tex_desc_size;
+   }
+
+   if (lima_dump_command_stream) {
+      unsigned tex_desc_oft = pp_tex_descs_offset +
+                           ctx->buffer_state[lima_ctx_buff_pp_tex_desc].offset;
+      printf("lima: add textures_desc at va %x\n",
+              ctx->pp_buffer->va + tex_desc_oft);
+      lima_dump_blob(ctx->pp_buffer->map + tex_desc_oft,
+                     ctx->buffer_state[lima_ctx_buff_pp_tex_desc].size,
+                     false);
+   }
+}

--- a/src/gallium/drivers/lima/lima_texture.h
+++ b/src/gallium/drivers/lima/lima_texture.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018 Lima Project
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sub license,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#ifndef H_LIMA_TEXTURE
+#define H_LIMA_TEXTURE
+
+void lima_update_textures(struct lima_context *ctx);
+
+#endif

--- a/src/gallium/drivers/lima/lima_util.c
+++ b/src/gallium/drivers/lima/lima_util.c
@@ -21,6 +21,7 @@
  *
  */
 
+#include <stdio.h>
 #include <time.h>
 
 #include "lima_util.h"
@@ -39,4 +40,20 @@ bool lima_get_absolute_timeout(uint64_t *timeout, bool relative)
       *timeout += current_ns;
    }
    return true;
+}
+
+void lima_dump_blob(void *data, int size, bool is_float)
+{
+   if (is_float) {
+      float *blob = data;
+      for (int i = 0; i * 4 < size; i += 4)
+         printf ("%04x: %f %f %f %f\n", i * 4,
+                 blob[i], blob[i + 1], blob[i + 2], blob[i + 3]);
+   }
+   else {
+      uint32_t *blob = data;
+      for (int i = 0; i * 4 < size; i += 4)
+         printf ("%04x: 0x%08x 0x%08x 0x%08x 0x%08x\n", i * 4,
+                 blob[i], blob[i + 1], blob[i + 2], blob[i + 3]);
+   }
 }

--- a/src/gallium/drivers/lima/lima_util.h
+++ b/src/gallium/drivers/lima/lima_util.h
@@ -30,5 +30,6 @@
 #define LIMA_PAGE_SIZE 4096
 
 bool lima_get_absolute_timeout(uint64_t *timeout, bool relative);
+void lima_dump_blob(void *data, int size, bool is_float);
 
 #endif


### PR DESCRIPTION
Currently only 2D textures are supported, not mipmaps yet and no support for "swizzled" textures (this is custom layout for 2D textures which is supposed to be faster on Mali hardware).

Codegen is not yet optimal and not everything is supported - e.g. coords can only be loaded from varying.

I'd really like it to be merged, since it's pretty large chunk, it is somewhat complete, and it's becoming hard to maintain it in a separate branch. We can optimize it and add features via separate PRs.