### PR TITLE
lima: call lima_bo_va_unmap when freeing bo

### DIFF
--- a/src/gallium/drivers/lima/lima_bo.c
+++ b/src/gallium/drivers/lima/lima_bo.c
@@ -130,8 +130,10 @@ void lima_bo_free(struct lima_bo *bo)
       util_hash_table_remove(screen->bo_flink_names, (void *)bo->flink_name);
    mtx_unlock(&screen->bo_table_lock);
 
-   if (bo->va)
+   if (bo->va) {
+      lima_bo_va_unmap(bo, bo->va);
       lima_va_range_free(bo->screen, bo->size, bo->va);
+   }
 
    lima_close_kms_handle(screen, bo->handle);
    free(bo);


### PR DESCRIPTION
Otherwise we'll get 'lima vm map va overlap' error from kernel if another bo takes va of freed bo

That fixes 'lima vm map va overlap' issue with glmark2-es-drm and now I'm hitting following assertion:
glmark2-es2-drm: lima_draw.c:1066: lima_flush: Assertion `ctx->buffer_state[lima_ctx_buff_sh_varying].offset + ctx->buffer_state[lima_ctx_buff_sh_varying].size <= sh_gl_pos_offset - sh_varying_offset' failed.

Looks like we need dynamic buffer allocation.