### PR TITLE
lima: renderonly: import dumb buffer from kms driver

### DIFF
--- a/src/gallium/winsys/exynos/drm/exynos_drm_winsys.c
+++ b/src/gallium/winsys/exynos/drm/exynos_drm_winsys.c
@@ -38,7 +38,7 @@ struct pipe_screen *exynos_screen_create(int fd)
        * PRIME buffer sharing.  The lima BO must be linear, which the SCANOUT
        * flag on allocation will have ensured.
        */
-      .create_for_resource = renderonly_create_gpu_import_for_resource,
+      .create_for_resource = renderonly_create_kms_dumb_buffer_for_resource,
       .kms_fd = fd,
       .gpu_fd = drmOpenWithType("lima", NULL, DRM_NODE_RENDER),
    };
@@ -46,7 +46,7 @@ struct pipe_screen *exynos_screen_create(int fd)
    if (ro.gpu_fd < 0)
       return NULL;
 
-   struct pipe_screen *screen = lima_drm_screen_create_renderonly(&ro, true);
+   struct pipe_screen *screen = lima_drm_screen_create_renderonly(&ro, false);
    if (!screen)
       close(ro.gpu_fd);
 

--- a/src/gallium/winsys/meson/drm/meson_drm_winsys.c
+++ b/src/gallium/winsys/meson/drm/meson_drm_winsys.c
@@ -38,7 +38,7 @@ struct pipe_screen *meson_screen_create(int fd)
        * PRIME buffer sharing.  The lima BO must be linear, which the SCANOUT
        * flag on allocation will have ensured.
        */
-      .create_for_resource = renderonly_create_gpu_import_for_resource,
+      .create_for_resource = renderonly_create_kms_dumb_buffer_for_resource,
       .kms_fd = fd,
       .gpu_fd = drmOpenWithType("lima", NULL, DRM_NODE_RENDER),
    };
@@ -46,7 +46,7 @@ struct pipe_screen *meson_screen_create(int fd)
    if (ro.gpu_fd < 0)
       return NULL;
 
-   struct pipe_screen *screen = lima_drm_screen_create_renderonly(&ro, true);
+   struct pipe_screen *screen = lima_drm_screen_create_renderonly(&ro, false);
    if (!screen)
       close(ro.gpu_fd);
 

--- a/src/gallium/winsys/rockchip/drm/rockchip_drm_winsys.c
+++ b/src/gallium/winsys/rockchip/drm/rockchip_drm_winsys.c
@@ -39,7 +39,7 @@ static struct pipe_screen *rockchip_screen_create_lima(int fd)
        * PRIME buffer sharing.  The lima BO must be linear, which the SCANOUT
        * flag on allocation will have ensured.
        */
-      .create_for_resource = renderonly_create_gpu_import_for_resource,
+      .create_for_resource = renderonly_create_kms_dumb_buffer_for_resource,
       .kms_fd = fd,
       .gpu_fd = drmOpenWithType("lima", NULL, DRM_NODE_RENDER),
    };
@@ -47,7 +47,7 @@ static struct pipe_screen *rockchip_screen_create_lima(int fd)
    if (ro.gpu_fd < 0)
       return NULL;
 
-   struct pipe_screen *screen = lima_drm_screen_create_renderonly(&ro, true);
+   struct pipe_screen *screen = lima_drm_screen_create_renderonly(&ro, false);
    if (!screen)
       close(ro.gpu_fd);
 

--- a/src/gallium/winsys/sun4i/drm/sun4i_drm_winsys.c
+++ b/src/gallium/winsys/sun4i/drm/sun4i_drm_winsys.c
@@ -38,7 +38,7 @@ struct pipe_screen *sun4i_screen_create(int fd)
        * PRIME buffer sharing.  The lima BO must be linear, which the SCANOUT
        * flag on allocation will have ensured.
        */
-      .create_for_resource = renderonly_create_gpu_import_for_resource,
+      .create_for_resource = renderonly_create_kms_dumb_buffer_for_resource,
       .kms_fd = fd,
       .gpu_fd = drmOpenWithType("lima", NULL, DRM_NODE_RENDER),
    };
@@ -46,7 +46,7 @@ struct pipe_screen *sun4i_screen_create(int fd)
    if (ro.gpu_fd < 0)
       return NULL;
 
-   struct pipe_screen *screen = lima_drm_screen_create_renderonly(&ro, true);
+   struct pipe_screen *screen = lima_drm_screen_create_renderonly(&ro, false);
    if (!screen)
       close(ro.gpu_fd);
 


### PR DESCRIPTION
This patch modifies the renderonly implementation to allocate a dumb
buffer for scanout in the kms driver and import it in lima.
In contrast, the previous renderonly implementation allocated a
contiguous buffer in lima and exported to the kms driver.
As stated in Issue #29, changing this around is useful to lima because
lima currently supports the contiguous allocation method mostly to
satisfy the requirement of exporting a scanout buffer to a kms display
driver (which may not support non-contiguous buffers).
So with this change, the contiguous allocation method may be dropped in
the future to reduce the complexity of the memory allocation in lima.

Signed-off-by: Erico Nunes <nunes.erico@gmail.com>