### PR TITLE
gpir basic conditional support

### DIFF
--- a/src/gallium/drivers/lima/ir/gp/codegen.c
+++ b/src/gallium/drivers/lima/ir/gp/codegen.c
@@ -196,6 +196,7 @@ static void gpir_codegen_add0_slot(gpir_codegen_instr *code, gpir_instr *instr)
    case gpir_op_add:
    case gpir_op_min:
    case gpir_op_max:
+   case gpir_op_lt:
       code->acc0_src0 = gpir_get_alu_input(node, alu->children[0]);
       code->acc0_src1 = gpir_get_alu_input(node, alu->children[1]);
 
@@ -219,6 +220,9 @@ static void gpir_codegen_add0_slot(gpir_codegen_instr *code, gpir_instr *instr)
          break;
       case gpir_op_max:
          code->acc_op = gpir_codegen_acc_op_max;
+         break;
+      case gpir_op_lt:
+         code->acc_op = gpir_codegen_acc_op_lt;
          break;
       default:
          assert(0);
@@ -256,6 +260,7 @@ static void gpir_codegen_add1_slot(gpir_codegen_instr *code, gpir_instr *instr)
    case gpir_op_add:
    case gpir_op_min:
    case gpir_op_max:
+   case gpir_op_lt:
       code->acc1_src0 = gpir_get_alu_input(node, alu->children[0]);
       code->acc1_src1 = gpir_get_alu_input(node, alu->children[1]);
 
@@ -279,6 +284,9 @@ static void gpir_codegen_add1_slot(gpir_codegen_instr *code, gpir_instr *instr)
          break;
       case gpir_op_max:
          code->acc_op = gpir_codegen_acc_op_max;
+         break;
+      case gpir_op_lt:
+         code->acc_op = gpir_codegen_acc_op_lt;
          break;
       default:
          assert(0);
@@ -538,6 +546,8 @@ static gpir_codegen_acc_op gpir_codegen_get_acc_op(gpir_op op)
       return gpir_codegen_acc_op_min;
    case gpir_op_max:
       return gpir_codegen_acc_op_max;
+   case gpir_op_lt:
+      return gpir_codegen_acc_op_lt;
    default:
       assert(0);
    }

--- a/src/gallium/drivers/lima/ir/gp/codegen.c
+++ b/src/gallium/drivers/lima/ir/gp/codegen.c
@@ -129,6 +129,12 @@ static void gpir_codegen_mul0_slot(gpir_codegen_instr *code, gpir_instr *instr)
       code->mul_op = gpir_codegen_mul_op_complex2;
       break;
 
+   case gpir_op_select:
+      code->mul0_src0 = gpir_get_alu_input(node, alu->children[2]);
+      code->mul0_src1 = gpir_get_alu_input(node, alu->children[0]);
+      code->mul_op = gpir_codegen_mul_op_select;
+      break;
+
    default:
       assert(0);
    }
@@ -173,6 +179,11 @@ static void gpir_codegen_mul1_slot(gpir_codegen_instr *code, gpir_instr *instr)
    case gpir_op_complex1:
       code->mul1_src0 = gpir_get_alu_input(node, alu->children[0]);
       code->mul1_src1 = gpir_get_alu_input(node, alu->children[2]);
+      break;
+
+   case gpir_op_select:
+      code->mul1_src0 = gpir_get_alu_input(node, alu->children[1]);
+      code->mul1_src1 = gpir_codegen_src_unused;
       break;
 
    default:

--- a/src/gallium/drivers/lima/ir/gp/instr.c
+++ b/src/gallium/drivers/lima/ir/gp/instr.c
@@ -352,13 +352,13 @@ static bool gpir_instr_slot_free(gpir_instr *instr, gpir_node *node)
       /* for node needs dist two slot, if the slot has a move, we can
        * spill it to other dist two slot without any side effect */
       int spill_to_start = GPIR_INSTR_SLOT_MUL0;
-      if (node->op == gpir_op_complex1)
+      if (node->op == gpir_op_complex1 || node->op == gpir_op_select)
          spill_to_start = GPIR_INSTR_SLOT_ADD0;
 
       if (!gpir_instr_spill_move(instr, node->sched.pos, spill_to_start))
          return false;
 
-      if (node->op == gpir_op_complex1) {
+      if (node->op == gpir_op_complex1 || node->op == gpir_op_select) {
          if (!gpir_instr_spill_move(instr, GPIR_INSTR_SLOT_MUL1, spill_to_start))
             return false;
       }
@@ -400,7 +400,7 @@ bool gpir_instr_try_insert_node(gpir_instr *instr, gpir_node *node)
 
    instr->slots[node->sched.pos] = node;
 
-   if (node->op == gpir_op_complex1)
+   if (node->op == gpir_op_complex1 || node->op == gpir_op_select)
       instr->slots[GPIR_INSTR_SLOT_MUL1] = node;
 
    return true;
@@ -426,7 +426,7 @@ void gpir_instr_remove_node(gpir_instr *instr, gpir_node *node)
 
    instr->slots[node->sched.pos] = NULL;
 
-   if (node->op == gpir_op_complex1)
+   if (node->op == gpir_op_complex1 || node->op == gpir_op_select)
       instr->slots[GPIR_INSTR_SLOT_MUL1] = NULL;
 }
 

--- a/src/gallium/drivers/lima/ir/gp/nir.c
+++ b/src/gallium/drivers/lima/ir/gp/nir.c
@@ -109,6 +109,7 @@ static int nir_to_gpir_opcodes[nir_num_opcodes] = {
    [nir_op_frcp] = gpir_op_rcp,
    [nir_op_frsq] = gpir_op_rsqrt,
    [nir_op_slt] = gpir_op_lt,
+   [nir_op_bcsel] = gpir_op_select,
 };
 
 static bool gpir_emit_alu(gpir_block *block, nir_instr *ni)

--- a/src/gallium/drivers/lima/ir/gp/nir.c
+++ b/src/gallium/drivers/lima/ir/gp/nir.c
@@ -108,6 +108,7 @@ static int nir_to_gpir_opcodes[nir_num_opcodes] = {
    [nir_op_fmax] = gpir_op_max,
    [nir_op_frcp] = gpir_op_rcp,
    [nir_op_frsq] = gpir_op_rsqrt,
+   [nir_op_slt] = gpir_op_lt,
 };
 
 static bool gpir_emit_alu(gpir_block *block, nir_instr *ni)

--- a/src/gallium/drivers/lima/ir/gp/node.c
+++ b/src/gallium/drivers/lima/ir/gp/node.c
@@ -77,6 +77,7 @@ const gpir_op_info gpir_op_infos[] = {
    [gpir_op_lt] = {
       .name = "lt",
       .src_neg = {true, true, false, false},
+      .slots = (int []) { GPIR_INSTR_SLOT_ADD0, GPIR_INSTR_SLOT_ADD1, GPIR_INSTR_SLOT_END },
    },
    [gpir_op_min] = {
       .name = "min",

--- a/src/gallium/drivers/lima/ir/gp/node.c
+++ b/src/gallium/drivers/lima/ir/gp/node.c
@@ -45,6 +45,8 @@ const gpir_op_info gpir_op_infos[] = {
    [gpir_op_select] = {
       .name = "select",
       .dest_neg = true,
+      .slots = (int []) { GPIR_INSTR_SLOT_MUL0, GPIR_INSTR_SLOT_END },
+      .may_consume_two_slots = true,
    },
    [gpir_op_complex1] = {
       .name = "complex1",


### PR DESCRIPTION
Implement 'less-than' and 'select' alu opcodes.
Tested with gbm-surface and the following silly vertex shader:

```
attribute vec3 positionIn;
void main()
{
    vec3 myvar = positionIn;
    if (positionIn.x > 0.1)
        myvar.y = 0.8;
    gl_Position = vec4(myvar, 1);
}
```
It causes the rightmost edge of the gbm-surface triangle to have its y-coordinate modified.