### PR TITLE
lima/gpir: support ge, floor, sign

### DIFF
--- a/src/compiler/glsl/glsl_to_nir.cpp
+++ b/src/compiler/glsl/glsl_to_nir.cpp
@@ -1817,7 +1817,7 @@ nir_visitor::visit(ir_expression *ir)
          else
             result = nir_uge(&b, srcs[0], srcs[1]);
       } else {
-         result = nir_slt(&b, srcs[0], srcs[1]);
+         result = nir_sge(&b, srcs[0], srcs[1]);
       }
       break;
    case ir_binop_equal:

--- a/src/gallium/drivers/lima/ir/gp/codegen.c
+++ b/src/gallium/drivers/lima/ir/gp/codegen.c
@@ -246,11 +246,15 @@ static void gpir_codegen_add0_slot(gpir_codegen_instr *code, gpir_instr *instr)
       break;
 
    case gpir_op_floor:
+   case gpir_op_sign:
       code->acc0_src0 = gpir_get_alu_input(node, alu->children[0]);
       code->acc0_src0_neg = alu->children_negate[0];
       switch (node->op) {
       case gpir_op_floor:
          code->acc_op = gpir_codegen_acc_op_floor;
+         break;
+      case gpir_op_sign:
+         code->acc_op = gpir_codegen_acc_op_sign;
          break;
       default:
          assert(0);
@@ -326,11 +330,15 @@ static void gpir_codegen_add1_slot(gpir_codegen_instr *code, gpir_instr *instr)
       break;
 
    case gpir_op_floor:
+   case gpir_op_sign:
       code->acc1_src0 = gpir_get_alu_input(node, alu->children[0]);
       code->acc1_src0_neg = alu->children_negate[0];
       switch (node->op) {
       case gpir_op_floor:
          code->acc_op = gpir_codegen_acc_op_floor;
+         break;
+      case gpir_op_sign:
+         code->acc_op = gpir_codegen_acc_op_sign;
          break;
       default:
          assert(0);
@@ -595,6 +603,8 @@ static gpir_codegen_acc_op gpir_codegen_get_acc_op(gpir_op op)
       return gpir_codegen_acc_op_ge;
    case gpir_op_floor:
       return gpir_codegen_acc_op_floor;
+   case gpir_op_sign:
+      return gpir_codegen_acc_op_sign;
    default:
       assert(0);
    }

--- a/src/gallium/drivers/lima/ir/gp/codegen.c
+++ b/src/gallium/drivers/lima/ir/gp/codegen.c
@@ -245,6 +245,18 @@ static void gpir_codegen_add0_slot(gpir_codegen_instr *code, gpir_instr *instr)
 
       break;
 
+   case gpir_op_floor:
+      code->acc0_src0 = gpir_get_alu_input(node, alu->children[0]);
+      code->acc0_src0_neg = alu->children_negate[0];
+      switch (node->op) {
+      case gpir_op_floor:
+         code->acc_op = gpir_codegen_acc_op_floor;
+         break;
+      default:
+         assert(0);
+      }
+      break;
+
    case gpir_op_neg:
       code->acc0_src0_neg = true;
    case gpir_op_mov:
@@ -311,6 +323,18 @@ static void gpir_codegen_add1_slot(gpir_codegen_instr *code, gpir_instr *instr)
          assert(0);
       }
 
+      break;
+
+   case gpir_op_floor:
+      code->acc1_src0 = gpir_get_alu_input(node, alu->children[0]);
+      code->acc1_src0_neg = alu->children_negate[0];
+      switch (node->op) {
+      case gpir_op_floor:
+         code->acc_op = gpir_codegen_acc_op_floor;
+         break;
+      default:
+         assert(0);
+      }
       break;
 
    case gpir_op_neg:
@@ -569,6 +593,8 @@ static gpir_codegen_acc_op gpir_codegen_get_acc_op(gpir_op op)
       return gpir_codegen_acc_op_lt;
    case gpir_op_ge:
       return gpir_codegen_acc_op_ge;
+   case gpir_op_floor:
+      return gpir_codegen_acc_op_floor;
    default:
       assert(0);
    }

--- a/src/gallium/drivers/lima/ir/gp/codegen.c
+++ b/src/gallium/drivers/lima/ir/gp/codegen.c
@@ -208,6 +208,7 @@ static void gpir_codegen_add0_slot(gpir_codegen_instr *code, gpir_instr *instr)
    case gpir_op_min:
    case gpir_op_max:
    case gpir_op_lt:
+   case gpir_op_ge:
       code->acc0_src0 = gpir_get_alu_input(node, alu->children[0]);
       code->acc0_src1 = gpir_get_alu_input(node, alu->children[1]);
 
@@ -234,6 +235,9 @@ static void gpir_codegen_add0_slot(gpir_codegen_instr *code, gpir_instr *instr)
          break;
       case gpir_op_lt:
          code->acc_op = gpir_codegen_acc_op_lt;
+         break;
+      case gpir_op_ge:
+         code->acc_op = gpir_codegen_acc_op_ge;
          break;
       default:
          assert(0);
@@ -272,6 +276,7 @@ static void gpir_codegen_add1_slot(gpir_codegen_instr *code, gpir_instr *instr)
    case gpir_op_min:
    case gpir_op_max:
    case gpir_op_lt:
+   case gpir_op_ge:
       code->acc1_src0 = gpir_get_alu_input(node, alu->children[0]);
       code->acc1_src1 = gpir_get_alu_input(node, alu->children[1]);
 
@@ -298,6 +303,9 @@ static void gpir_codegen_add1_slot(gpir_codegen_instr *code, gpir_instr *instr)
          break;
       case gpir_op_lt:
          code->acc_op = gpir_codegen_acc_op_lt;
+         break;
+      case gpir_op_ge:
+         code->acc_op = gpir_codegen_acc_op_ge;
          break;
       default:
          assert(0);
@@ -559,6 +567,8 @@ static gpir_codegen_acc_op gpir_codegen_get_acc_op(gpir_op op)
       return gpir_codegen_acc_op_max;
    case gpir_op_lt:
       return gpir_codegen_acc_op_lt;
+   case gpir_op_ge:
+      return gpir_codegen_acc_op_ge;
    default:
       assert(0);
    }

--- a/src/gallium/drivers/lima/ir/gp/nir.c
+++ b/src/gallium/drivers/lima/ir/gp/nir.c
@@ -111,6 +111,7 @@ static int nir_to_gpir_opcodes[nir_num_opcodes] = {
    [nir_op_slt] = gpir_op_lt,
    [nir_op_sge] = gpir_op_ge,
    [nir_op_bcsel] = gpir_op_select,
+   [nir_op_ffloor] = gpir_op_floor,
 };
 
 static bool gpir_emit_alu(gpir_block *block, nir_instr *ni)

--- a/src/gallium/drivers/lima/ir/gp/nir.c
+++ b/src/gallium/drivers/lima/ir/gp/nir.c
@@ -109,6 +109,7 @@ static int nir_to_gpir_opcodes[nir_num_opcodes] = {
    [nir_op_frcp] = gpir_op_rcp,
    [nir_op_frsq] = gpir_op_rsqrt,
    [nir_op_slt] = gpir_op_lt,
+   [nir_op_sge] = gpir_op_ge,
    [nir_op_bcsel] = gpir_op_select,
 };
 

--- a/src/gallium/drivers/lima/ir/gp/nir.c
+++ b/src/gallium/drivers/lima/ir/gp/nir.c
@@ -112,6 +112,7 @@ static int nir_to_gpir_opcodes[nir_num_opcodes] = {
    [nir_op_sge] = gpir_op_ge,
    [nir_op_bcsel] = gpir_op_select,
    [nir_op_ffloor] = gpir_op_floor,
+   [nir_op_fsign] = gpir_op_sign,
 };
 
 static bool gpir_emit_alu(gpir_block *block, nir_instr *ni)

--- a/src/gallium/drivers/lima/ir/gp/node.c
+++ b/src/gallium/drivers/lima/ir/gp/node.c
@@ -67,6 +67,7 @@ const gpir_op_info gpir_op_infos[] = {
    [gpir_op_floor] = {
       .name = "floor",
       .src_neg = {true, false, false, false},
+      .slots = (int []) { GPIR_INSTR_SLOT_ADD0, GPIR_INSTR_SLOT_ADD1, GPIR_INSTR_SLOT_END },
    },
    [gpir_op_sign] = {
       .name = "sign",

--- a/src/gallium/drivers/lima/ir/gp/node.c
+++ b/src/gallium/drivers/lima/ir/gp/node.c
@@ -75,6 +75,7 @@ const gpir_op_info gpir_op_infos[] = {
    [gpir_op_ge] = {
       .name = "ge",
       .src_neg = {true, true, false, false},
+      .slots = (int []) { GPIR_INSTR_SLOT_ADD0, GPIR_INSTR_SLOT_ADD1, GPIR_INSTR_SLOT_END },
    },
    [gpir_op_lt] = {
       .name = "lt",

--- a/src/gallium/drivers/lima/ir/gp/node.c
+++ b/src/gallium/drivers/lima/ir/gp/node.c
@@ -72,6 +72,7 @@ const gpir_op_info gpir_op_infos[] = {
    [gpir_op_sign] = {
       .name = "sign",
       .src_neg = {true, false, false, false},
+      .slots = (int []) { GPIR_INSTR_SLOT_ADD0, GPIR_INSTR_SLOT_ADD1, GPIR_INSTR_SLOT_END },
    },
    [gpir_op_ge] = {
       .name = "ge",


### PR DESCRIPTION
For the first patch, there is some discussion at:
https://lists.freedesktop.org/archives/mesa-dev/2018-April/192317.html
We may have to consider changing the handling of ints/floats as suggested there but as of now it already has one reviewed-by and no doubt it's a bug in the optimization path we're currently hitting.

I tested ge, floor, sign with gbm-surface and the following vertex shaders that insert the according nir op:

ge:
```
attribute vec3 positionIn;
void main()
{
    vec3 myvar = positionIn;
    if (positionIn.x >= positionIn.y)
        myvar.y = 0.8;
    gl_Position = vec4(myvar, 1);
}
```
floor:
```
attribute vec3 positionIn;
void main()
{
    vec3 myvar = positionIn;
    myvar.x += 0.1;
    myvar.y += 0.1;
    myvar.z += 0.1;
    gl_Position = vec4(floor(myvar.x), floor(myvar.y), floor(myvar.z), 1);
}
```
sign:
```
attribute vec3 positionIn;
void main()
{
    vec3 myvar = positionIn;
    myvar.x += 0.1;
    myvar.y += 0.1;
    gl_Position = vec4(sign(myvar.x), sign(myvar.y), myvar.z, 1);
}
```
