### PR TITLE
lima nir: alias nir_op_fmov to ppir_op_mov

### DIFF
--- a/src/gallium/drivers/lima/ir/pp/nir.c
+++ b/src/gallium/drivers/lima/ir/pp/nir.c
@@ -117,6 +117,7 @@ static int nir_to_ppir_opcodes[nir_num_opcodes] = {
    /* not supported */
    [0 ... nir_last_opcode] = -1,
 
+   [nir_op_fmov] = ppir_op_mov,
    [nir_op_imov] = ppir_op_mov,
    [nir_op_fmul] = ppir_op_mul,
    [nir_op_fadd] = ppir_op_add,


### PR DESCRIPTION
Pretty much untested. It compiles and kodi doesn't crash anymore:

```Apr 20 11:32:08 libretech-cc kodi-standalone[224]: libEGL info: found extension DRI_NoError version 1
Apr 20 11:32:08 libretech-cc kodi-standalone[224]: libEGL debug: did not find optional extension DRI_Robustness version 1
Apr 20 11:32:08 libretech-cc kodi-standalone[224]: libEGL debug: did not find optional extension DRI_FlushControl version 1
Apr 20 11:32:08 libretech-cc kodi-standalone[224]: libEGL debug: No DRI config supports native format 0x30335258
Apr 20 11:32:08 libretech-cc kodi-standalone[224]: libEGL debug: No DRI config supports native format 0x30335241
Apr 20 11:32:08 libretech-cc kodi-standalone[224]: libEGL debug: No DRI config supports native format 0x36314752
Apr 20 11:32:08 libretech-cc kodi-standalone[224]: libEGL debug: the best driver is DRI2
Apr 20 11:32:08 libretech-cc kodi-standalone[224]: libEGL debug: EGL user error 0x300d (EGL_BAD_SURFACE) in eglSwapBuffers```

I'll try running piglit when I get some more time this weekend.