### PR TITLE
lima: implement basic depth support

### DIFF
--- a/src/gallium/drivers/lima/lima_screen.c
+++ b/src/gallium/drivers/lima/lima_screen.c
@@ -245,6 +245,8 @@ lima_screen_is_format_supported(struct pipe_screen *pscreen,
    if (usage & PIPE_BIND_DEPTH_STENCIL) {
       switch (format) {
       case PIPE_FORMAT_Z16_UNORM:
+      case PIPE_FORMAT_Z24_UNORM_S8_UINT:
+      case PIPE_FORMAT_Z24X8_UNORM:
          break;
       default:
          return FALSE;
@@ -275,6 +277,8 @@ lima_screen_is_format_supported(struct pipe_screen *pscreen,
       switch (format) {
       case PIPE_FORMAT_R8G8B8X8_UNORM:
       case PIPE_FORMAT_R8G8B8A8_UNORM:
+      case PIPE_FORMAT_B8G8R8X8_UNORM:
+      case PIPE_FORMAT_B8G8R8A8_UNORM:
          break;
       default:
          return FALSE;


### PR DESCRIPTION
mali400 uses on-chip tile buffer to store depth and stencil values,
so no separate buffer is needed if FBO doesn't have depth/stencil attachment

We still need to figure out how to render to depth/stencil buffer.

Signed-off-by: Vasily Khoruzhick <anarsoul@gmail.com>