### PR TITLE
lima/gpir: eq and ne support

### DIFF
--- a/src/gallium/drivers/lima/ir/gp/gpir.h
+++ b/src/gallium/drivers/lima/ir/gp/gpir.h
@@ -94,6 +94,8 @@ typedef enum {
    gpir_op_cos,
    gpir_op_tan,
    gpir_op_branch_uncond,
+   gpir_op_eq,
+   gpir_op_ne,
 
    /* auxiliary ops */
    gpir_op_dummy_f,

--- a/src/gallium/drivers/lima/ir/gp/nir.c
+++ b/src/gallium/drivers/lima/ir/gp/nir.c
@@ -113,6 +113,8 @@ static int nir_to_gpir_opcodes[nir_num_opcodes] = {
    [nir_op_bcsel] = gpir_op_select,
    [nir_op_ffloor] = gpir_op_floor,
    [nir_op_fsign] = gpir_op_sign,
+   [nir_op_seq] = gpir_op_eq,
+   [nir_op_sne] = gpir_op_ne,
 };
 
 static bool gpir_emit_alu(gpir_block *block, nir_instr *ni)

--- a/src/gallium/drivers/lima/ir/gp/nir.c
+++ b/src/gallium/drivers/lima/ir/gp/nir.c
@@ -115,6 +115,8 @@ static int nir_to_gpir_opcodes[nir_num_opcodes] = {
    [nir_op_fsign] = gpir_op_sign,
    [nir_op_seq] = gpir_op_eq,
    [nir_op_sne] = gpir_op_ne,
+   [nir_op_fand] = gpir_op_min,
+   [nir_op_for] = gpir_op_max,
 };
 
 static bool gpir_emit_alu(gpir_block *block, nir_instr *ni)

--- a/src/gallium/drivers/lima/ir/gp/node.c
+++ b/src/gallium/drivers/lima/ir/gp/node.c
@@ -110,6 +110,18 @@ const gpir_op_info gpir_op_infos[] = {
          GPIR_INSTR_SLOT_END
       },
    },
+   [gpir_op_eq] = {
+      .name = "eq",
+      .slots = (int []) {
+         GPIR_INSTR_SLOT_ADD0, GPIR_INSTR_SLOT_ADD1, GPIR_INSTR_SLOT_END
+      },
+   },
+   [gpir_op_ne] = {
+      .name = "ne",
+      .slots = (int []) {
+         GPIR_INSTR_SLOT_ADD0, GPIR_INSTR_SLOT_ADD1, GPIR_INSTR_SLOT_END
+      },
+   },
    [gpir_op_clamp_const] = {
       .name = "clamp_const",
    },


### PR DESCRIPTION
Tested on A20 Mali400 with gbm-surface and the following shaders:

eq:
```
attribute vec3 positionIn;
void main()
{
    vec3 myvar = positionIn;
    if (positionIn.x == 1.0)
        myvar.y = 0.5;
    gl_Position = vec4(myvar, 1);
}
```

ne:
```
attribute vec3 positionIn;
void main()
{
    vec3 myvar = positionIn;
    if (positionIn.x != 1.0)
        myvar.y = 0.5;
    gl_Position = vec4(myvar, 1);
}
```

and:
```
attribute vec3 positionIn;
void main()
{
    vec3 myvar = positionIn;
    if ((positionIn.x == 1.0) && (positionIn.y == 1.0))
        myvar.y = 0.5;
    gl_Position = vec4(myvar, 1);
}
```

or:
```
attribute vec3 positionIn;
void main()
{
    vec3 myvar = positionIn;
    if ((positionIn.x == 1.0) || (positionIn.y == 1.0))
        myvar.y = 0.5;
    gl_Position = vec4(myvar, 1);
}
```