### PR TITLE
lima/gpir: implement abs lowering function

### DIFF
--- a/src/gallium/drivers/lima/ir/gp/lower.c
+++ b/src/gallium/drivers/lima/ir/gp/lower.c
@@ -424,12 +424,32 @@ static bool gpir_lower_eq_ne(gpir_block *block, gpir_node *node)
    return true;
 }
 
+/*
+ * There is no 'abs' opcode.
+ * abs(a) is lowered to max(a, -a)
+ */
+static bool gpir_lower_abs(gpir_block *block, gpir_node *node)
+{
+   gpir_alu_node *alu = gpir_node_to_alu(node);
+
+   assert(node->op == gpir_op_abs);
+
+   node->op = gpir_op_max;
+
+   alu->children[1] = alu->children[0];
+   alu->children_negate[1] = true;
+   alu->num_child = 2;
+
+   return true;
+}
+
 static bool (*gpir_lower_funcs[gpir_op_num])(gpir_block *, gpir_node *) = {
    [gpir_op_neg] = gpir_lower_neg,
    [gpir_op_rcp] = gpir_lower_complex,
    [gpir_op_rsqrt] = gpir_lower_complex,
    [gpir_op_eq] = gpir_lower_eq_ne,
    [gpir_op_ne] = gpir_lower_eq_ne,
+   [gpir_op_abs] = gpir_lower_abs,
 };
 
 bool gpir_pre_rsched_lower_prog(gpir_compiler *comp)

--- a/src/gallium/drivers/lima/ir/gp/nir.c
+++ b/src/gallium/drivers/lima/ir/gp/nir.c
@@ -117,6 +117,7 @@ static int nir_to_gpir_opcodes[nir_num_opcodes] = {
    [nir_op_sne] = gpir_op_ne,
    [nir_op_fand] = gpir_op_min,
    [nir_op_for] = gpir_op_max,
+   [nir_op_fabs] = gpir_op_abs,
 };
 
 static bool gpir_emit_alu(gpir_block *block, nir_instr *ni)


### PR DESCRIPTION
There is no 'abs' opcode.
abs(a) is lowered to max(a, -a)

Signed-off-by: Erico Nunes <nunes.erico@gmail.com>