### PR TITLE
Add support for tiled textures

### DIFF
--- a/src/gallium/drivers/lima/Makefile.sources
+++ b/src/gallium/drivers/lima/Makefile.sources
@@ -51,4 +51,6 @@ C_SOURCES := \
 	  lima_texture.h \
 	  lima_fence.c \
 	  lima_fence.h \
+	  lima_tiling.c \
+	  lima_tiling.h \
 	  $(ir_SOURCES)

--- a/src/gallium/drivers/lima/lima_draw.c
+++ b/src/gallium/drivers/lima/lima_draw.c
@@ -1067,7 +1067,13 @@ lima_pack_pp_frame_reg(struct lima_context *ctx, uint32_t *frame_reg,
    wb[0].type = 0x02; /* 1 for depth, stencil */
    wb[0].address = res->bo->va;
    wb[0].pixel_format = 0x03; /* BGRA8888 */
-   wb[0].pitch = res->stride / 8;
+   if (res->tiled) {
+      wb[0].pixel_layout = 0x2;
+      wb[0].pitch = align(ctx->framebuffer.width, 16) / 16;
+   } else {
+      wb[0].pixel_layout = 0x0;
+      wb[0].pitch = res->stride / 8;
+   }
    wb[0].mrt_bits = swap_channels ? 0x4 : 0x0;
 }
 

--- a/src/gallium/drivers/lima/lima_resource.c
+++ b/src/gallium/drivers/lima/lima_resource.c
@@ -155,6 +155,23 @@ lima_resource_create(struct pipe_screen *pscreen,
    return pres;
 }
 
+static struct pipe_resource *
+lima_resource_create_with_modifiers(struct pipe_screen *pscreen,
+                                   const struct pipe_resource *templat,
+                                   const uint64_t *modifiers,
+                                   int count)
+{
+   struct pipe_resource tmpl = *templat;
+
+   /*
+    * We currently assume that all buffers allocated through this interface
+    * should be scanout enabled.
+    */
+   tmpl.bind |= PIPE_BIND_SCANOUT;
+
+   return lima_resource_create(pscreen, &tmpl);
+}
+
 static void
 lima_resource_destroy(struct pipe_screen *pscreen, struct pipe_resource *pres)
 {
@@ -237,6 +254,7 @@ void
 lima_resource_screen_init(struct lima_screen *screen)
 {
    screen->base.resource_create = lima_resource_create;
+   screen->base.resource_create_with_modifiers = lima_resource_create_with_modifiers;
    screen->base.resource_from_handle = lima_resource_from_handle;
    screen->base.resource_destroy = lima_resource_destroy;
    screen->base.resource_get_handle = lima_resource_get_handle;

--- a/src/gallium/drivers/lima/lima_resource.c
+++ b/src/gallium/drivers/lima/lima_resource.c
@@ -39,6 +39,7 @@
 #include "lima_bo.h"
 #include "lima_util.h"
 #include "lima_drm.h"
+#include "lima_tiling.h"
 
 static struct pipe_resource *
 lima_resource_create_scanout(struct pipe_screen *pscreen,
@@ -72,6 +73,7 @@ lima_resource_create_scanout(struct pipe_screen *pscreen,
 
    struct lima_resource *res = lima_resource(pres);
    res->scanout = scanout;
+   res->tiled = false;
 
    return pres;
 }
@@ -84,10 +86,18 @@ lima_resource_create_bo(struct pipe_screen *pscreen,
    struct lima_screen *screen = lima_screen(pscreen);
    struct lima_resource *res;
    struct pipe_resource *pres;
+   bool should_tile = true;
 
    res = CALLOC_STRUCT(lima_resource);
    if (!res)
       return NULL;
+
+   /* VBOs/PBOs are untiled (and 1 height). */
+   if (templat->target == PIPE_BUFFER)
+      should_tile = false;
+
+   if (templat->bind & PIPE_BIND_LINEAR)
+      should_tile = false;
 
    res->base = *templat;
    res->base.screen = pscreen;
@@ -95,10 +105,12 @@ lima_resource_create_bo(struct pipe_screen *pscreen,
 
    /* TODO: mipmap */
    pres = &res->base;
-   res->stride = util_format_get_stride(pres->format, width);
+   res->tiled = should_tile;
+   res->stride = util_format_get_stride(pres->format, should_tile ? align(width, 16) : width);
 
    uint32_t size = res->stride *
-      util_format_get_nblocksy(pres->format, height) *
+      util_format_get_nblocksy(pres->format,
+                               should_tile ? align(height, 16) : height) *
       pres->array_size * pres->depth0;
    size = align(size, LIMA_PAGE_SIZE);
 
@@ -368,13 +380,61 @@ lima_transfer_map(struct pipe_context *pctx,
    ptrans->usage = usage;
    ptrans->box = *box;
    ptrans->stride = res->stride;
+   trans->res = res;
 
    *pptrans = ptrans;
 
-   return bo->map + box->z * ptrans->layer_stride +
-      box->y / util_format_get_blockheight(pres->format) * ptrans->stride +
-      box->x / util_format_get_blockwidth(pres->format) *
-      util_format_get_blocksize(pres->format);
+   if (res->tiled) {
+      uint32_t box_x1, box_y1, box_x2, box_y2;
+      uint32_t box_start_x, box_start_y;
+      bool needs_load = false;
+
+      /* No direct mappings of tiled, since we need to manually
+       * tile/untile.
+       */
+      if (usage & PIPE_TRANSFER_MAP_DIRECTLY)
+         return NULL;
+
+      if (usage & PIPE_TRANSFER_READ)
+         needs_load = true;
+
+      box_start_x = ptrans->box.x & 15;
+      box_start_y = ptrans->box.y & 15;
+
+      /* TODO: load only borders, not whole box */
+      if (box_start_x || box_start_y)
+         needs_load = true;
+
+      if (((ptrans->box.x + ptrans->box.width) & 15) ||
+          ((ptrans->box.y + ptrans->box.height) & 15))
+         needs_load = true;
+
+      /* Align box to tile boundaries */
+      box_x1 = align(ptrans->box.x, 16);
+      box_y1 = align(ptrans->box.y, 16);
+      box_x2 = align(box_x1 + ptrans->box.width, 16);
+      box_y2 = align(box_y1 + ptrans->box.height, 16);
+
+      ptrans->box.x = box_x1;
+      ptrans->box.y = box_y1;
+      ptrans->box.width = box_x2 - box_x1;
+      ptrans->box.height = box_y2 - box_y1;
+      trans->map = malloc(ptrans->stride * ptrans->box.height * ptrans->box.depth);
+      if (needs_load)
+         lima_load_tiled_image(trans->map, bo->map,
+                              &ptrans->box,
+                              ptrans->stride,
+                              util_format_get_blocksize(pres->format));
+      return trans->map + box->z * ptrans->layer_stride +
+         box_start_y / util_format_get_blockheight(pres->format) * ptrans->stride +
+         box_start_x / util_format_get_blockwidth(pres->format) *
+         util_format_get_blocksize(pres->format);
+   } else {
+      return bo->map + box->z * ptrans->layer_stride +
+         box->y / util_format_get_blockheight(pres->format) * ptrans->stride +
+         box->x / util_format_get_blockwidth(pres->format) *
+         util_format_get_blocksize(pres->format);
+   }
 }
 
 static void
@@ -391,6 +451,19 @@ lima_transfer_unmap(struct pipe_context *pctx,
 {
    struct lima_context *ctx = lima_context(pctx);
    struct lima_transfer *trans = lima_transfer(ptrans);
+   struct lima_resource *res = trans->res;
+   struct lima_bo *bo = res->bo;
+   struct pipe_resource *pres;
+
+   if (trans->map) {
+      pres = &res->base;
+      if (ptrans->usage & PIPE_TRANSFER_WRITE)
+         lima_store_tiled_image(bo->map, trans->map,
+                              &ptrans->box,
+                              ptrans->stride,
+                              util_format_get_blocksize(pres->format));
+      free(trans->map);
+   }
 
    pipe_resource_reference(&ptrans->resource, NULL);
    slab_free(&ctx->transfer_pool, trans);

--- a/src/gallium/drivers/lima/lima_texture.c
+++ b/src/gallium/drivers/lima/lima_texture.c
@@ -175,8 +175,8 @@ lima_update_textures(struct lima_context *ctx)
 
    assert (lima_tex->num_samplers <= 16);
 
-   /* Nothing to do - we have no samplers */
-   if (!lima_tex->num_samplers)
+   /* Nothing to do - we have no samplers or textures */
+   if (!lima_tex->num_samplers || !lima_tex->num_textures)
       return;
 
    unsigned size = lima_tex_list_size + lima_tex->num_samplers * lima_tex_desc_size;

--- a/src/gallium/drivers/lima/lima_texture.c
+++ b/src/gallium/drivers/lima/lima_texture.c
@@ -95,8 +95,10 @@ lima_update_tex_desc(struct lima_context *ctx, struct lima_sampler_state *sample
    width = prsc->width0;
    height = prsc->height0;
 
-   /* "Swizzled" textures aren't supported yet */
-   layout = 0;
+   if (lima_res->tiled)
+      layout = 3;
+   else
+      layout = 0;
 
    desc[0] = pipe_format_to_lima(prsc->format);
 

--- a/src/gallium/drivers/lima/lima_tiling.c
+++ b/src/gallium/drivers/lima/lima_tiling.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2011-2013 Luc Verhaegen <libv@skynet.be>
+ * Copyright (c) 2018 Alyssa Rosenzweig <alyssa@rosenzweig.io>
+ * Copyright (c) 2018 Lima Project
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sub license,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice (including the
+ * next paragraph) shall be included in all copies or substantial portions
+ * of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ *
+ */
+
+#include "lima_tiling.h"
+
+uint32_t space_filler[16][16] = {
+   { 0, 1, 4, 5, 16, 17, 20, 21, 64, 65, 68, 69, 80, 81, 84, 85, },
+   { 3, 2, 7, 6, 19, 18, 23, 22, 67, 66, 71, 70, 83, 82, 87, 86, },
+   { 12, 13, 8, 9, 28, 29, 24, 25, 76, 77, 72, 73, 92, 93, 88, 89, },
+   { 15, 14, 11, 10, 31, 30, 27, 26, 79, 78, 75, 74, 95, 94, 91, 90, },
+   { 48, 49, 52, 53, 32, 33, 36, 37, 112, 113, 116, 117, 96, 97, 100, 101, },
+   { 51, 50, 55, 54, 35, 34, 39, 38, 115, 114, 119, 118, 99, 98, 103, 102, },
+   { 60, 61, 56, 57, 44, 45, 40, 41, 124, 125, 120, 121, 108, 109, 104, 105, },
+   { 63, 62, 59, 58, 47, 46, 43, 42, 127, 126, 123, 122, 111, 110, 107, 106, },
+   { 192, 193, 196, 197, 208, 209, 212, 213, 128, 129, 132, 133, 144, 145, 148, 149, },
+   { 195, 194, 199, 198, 211, 210, 215, 214, 131, 130, 135, 134, 147, 146, 151, 150, },
+   { 204, 205, 200, 201, 220, 221, 216, 217, 140, 141, 136, 137, 156, 157, 152, 153, },
+   { 207, 206, 203, 202, 223, 222, 219, 218, 143, 142, 139, 138, 159, 158, 155, 154, },
+   { 240, 241, 244, 245, 224, 225, 228, 229, 176, 177, 180, 181, 160, 161, 164, 165, },
+   { 243, 242, 247, 246, 227, 226, 231, 230, 179, 178, 183, 182, 163, 162, 167, 166, },
+   { 252, 253, 248, 249, 236, 237, 232, 233, 188, 189, 184, 185, 172, 173, 168, 169, },
+   { 255, 254, 251, 250, 239, 238, 235, 234, 191, 190, 187, 186, 175, 174, 171, 170, },
+};
+
+void lima_store_tiled_image(void *dst, const void *src,
+                           const struct pipe_box *box,
+                           uint32_t stride,
+                           uint32_t bpp)
+{
+   for (int y = box->y; y < box->height; ++y) {
+      int block_y = y & ~0x0f;
+      int rem_y = y & 0x0F;
+      int block_start_s = block_y * stride;
+      int source_start = y * stride;
+
+      for (int x = box->x; x < box->width; ++x) {
+         int block_x_s = (x >> 4) * 256;
+         int rem_x = x & 0x0F;
+
+         int index = space_filler[rem_y][rem_x];
+         const uint8_t *src8 = src;
+         const uint8_t *source = &src8[source_start + bpp * x];
+         uint8_t *dest = dst + block_start_s + bpp * (block_x_s + index);
+
+         for (int b = 0; b < bpp; ++b)
+            dest[b] = source[b];
+      }
+   }
+}
+
+void lima_load_tiled_image(void *dst, const void *src,
+                           const struct pipe_box *box,
+                           uint32_t stride,
+                           uint32_t bpp)
+{
+   for (int y = box->y; y < box->height; ++y) {
+      int block_y = y & ~0x0f;
+      int rem_y = y & 0x0F;
+      int block_start_s = block_y * stride;
+      int dest_start = y * stride;
+
+      for (int x = box->x; x < box->width; ++x) {
+         int block_x_s = (x >> 4) * 256;
+         int rem_x = x & 0x0F;
+
+         int index = space_filler[rem_y][rem_x];
+         uint8_t *dst8 = dst;
+         uint8_t *dest = &dst8[dest_start + bpp * x];
+         const uint8_t *source = src + block_start_s + bpp * (block_x_s + index);
+
+         for (int b = 0; b < bpp; ++b)
+            dest[b] = source[b];
+      }
+   }
+}

--- a/src/gallium/drivers/lima/lima_tiling.h
+++ b/src/gallium/drivers/lima/lima_tiling.h
@@ -1,5 +1,7 @@
 /*
- * Copyright (c) 2017 Lima Project
+ * Copyright (c) 2011-2013 Luc Verhaegen <libv@skynet.be>
+ * Copyright (c) 2018 Alyssa Rosenzweig <alyssa@rosenzweig.io>
+ * Copyright (c) 2018 Lima Project
  *
  * Permission is hereby granted, free of charge, to any person obtaining a
  * copy of this software and associated documentation files (the "Software"),
@@ -22,55 +24,19 @@
  *
  */
 
-#ifndef H_LIMA_RESOURCE
-#define H_LIMA_RESOURCE
+#ifndef H_LIMA_TILING
+#define H_LIMA_TILING
 
-#include "pipe/p_state.h"
+#include "util/u_box.h"
 
-struct lima_screen;
+void lima_load_tiled_image(void *dst, const void *src,
+                           const struct pipe_box *box,
+                           uint32_t stride,
+                           uint32_t bpp);
 
-struct lima_resource {
-   struct pipe_resource base;
-
-   struct renderonly_scanout *scanout;
-   struct lima_bo *bo;
-   uint32_t stride;
-   bool tiled;
-};
-
-struct lima_surface {
-   struct pipe_surface base;
-   int tiled_w, tiled_h;
-};
-
-struct lima_transfer {
-   struct pipe_transfer base;
-   struct lima_resource *res;
-   void *map;
-};
-
-static inline struct lima_resource *
-lima_resource(struct pipe_resource *res)
-{
-   return (struct lima_resource *)res;
-}
-
-static inline struct lima_surface *
-lima_surface(struct pipe_surface *surf)
-{
-   return (struct lima_surface *)surf;
-}
-
-static inline struct lima_transfer *
-lima_transfer(struct pipe_transfer *trans)
-{
-   return (struct lima_transfer *)trans;
-}
-
-void
-lima_resource_screen_init(struct lima_screen *screen);
-
-void
-lima_resource_context_init(struct lima_context *ctx);
+void lima_store_tiled_image(void *dst, const void *src,
+                           const struct pipe_box *box,
+                           uint32_t stride,
+                           uint32_t bpp);
 
 #endif


### PR DESCRIPTION
This is initial support for tiled textures - tiling/untiling routines aren't optimized yet.

lima-18.1 branch can't compile fragment shader of "kmscube -M rgba" due to ppir regalloc failure, I'm using this patch as a workaround for testing: anarsoul/mesa-lima@14e0665

Tested with kmscube -M rgba from my repo (it uses 500x500 texture) and gbm-surface-fbo from your gfx repo with 260x260 fbo.